### PR TITLE
Adding docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM golang:1.7
+
+ARG "version=0.1.0-dev"
+ARG "build_date=unknown"
+ARG "commit_hash=unknown"
+ARG "vcs_url=unknown"
+ARG "vcs_branch=unknown"
+
+LABEL org.label-schema.vendor="craigmj" \
+    org.label-schema.name="phpfpm_exporter" \
+    org.label-schema.description="Prometheus exporter for php-fpm processes." \
+    org.label-schema.usage="/src/README.md" \
+    org.label-schema.url="https://github.com/craigmj/phpfpm_exporter/blob/master/README.md" \
+    org.label-schema.vcs-url=$vcs_url \
+    org.label-schema.vcs-branch=$vcs_branch \
+    org.label-schema.vcs-ref=$commit_hash \
+    org.label-schema.version=$version \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.docker.cmd.devel="" \
+    org.label-schema.build-date=$build_date
+
+
+RUN git clone https://github.com/craigmj/phpfpm_exporter /tmp/phpfpm_exporter \
+ && cd /tmp/phpfpm_exporter \
+ && /tmp/phpfpm_exporter/build.sh \
+ && mv /tmp/phpfpm_exporter/bin/phpfpm_exporter /bin/phpfpm_exporter
+
+ENTRYPOINT ["/bin/phpfpm_exporter"]
+CMD ["-help"]
+
+#FROM scratch
+#COPY --from=0 /tmp/phpfpm_exporter/bin/phpfpm_exporter .
+#ENTRYPOINT ["./phpfpm_exporter"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Start the exporter with
 
 	phpfpm_exporter
 
+## Running from Docker
+
+This service is provided as a docker image that can be run with the command
+
+    docker run --rm softonic/phpfpm_exporter \
+      -status.url=http://nginx/status?json \
+      -listen.address 0.0.0.0:9099
+
+Just change the example parameters to fit your use case.
+
 # Command Line Options
 
 The exporter accepts 3 command line options
@@ -65,14 +75,14 @@ The size of the listen queue for each pool.
 
 * `pool` the fpm pool
 
-* `metric` one of 
+* `metric` one of
 
   * `current` : the `listen queue` value from php-fpm: the number of requests in the queue of pending connections
 
   * `max` : the `max listen queue` value from php-fpm: the maximum number of requests in the queue of pending connections since FPM started
 
   * `len` : the `listen queue len` value from php-fpm: the size of the socket queue of pending connections
-  
+
 ## phpfpm_processes_count
 
 The number of processes in each pool.

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# $IMAGE_NAME var is injected into the build so the tag is correct.
+
+echo "Build hook running"
+docker build \
+  --build-arg version=$(git describe --tags) \
+  --build-arg commit_hash=$(git rev-parse HEAD) \
+  --build-arg vcs_url=$(git config --get remote.origin.url) \
+  --build-arg vcs_branch=$(git rev-parse --abbrev-ref HEAD) \
+  --build-arg build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+  -t $IMAGE_NAME .


### PR DESCRIPTION
This is an initial approach to a docker image. In case you already have a docker hub account you can configure the automatic build and change the README.md reference to the image name, changing `softonic` by your user namespace.