### PR TITLE
Fix package import path

### DIFF
--- a/cmd/phpfpm_exporter.go
+++ b/cmd/phpfpm_exporter.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 
-	phpfpm "github.com/craigm/phpfpm_exporter/pkg"
+	phpfpm "github.com/craigmj/phpfpm_exporter/pkg"
 )
 
 func main() {


### PR DESCRIPTION
Fixes `cmd/phpfpm_exporter.go:6:2: cannot find package "github.com/craigm/phpfpm_exporter/pkg"`